### PR TITLE
Support for output files

### DIFF
--- a/src/jail.h
+++ b/src/jail.h
@@ -43,7 +43,7 @@ class Jail{
 	//Action commands
 	string commandAvailable(int memRequested);
 	void commandRequest(mapstruct &parsedata, string &adminticket,string &monitorticket,string &executionticket);
-	void commandGetResult(string adminticket,string &compilation,string &execution,bool &executed,bool &interactive);
+	void commandGetResult(string adminticket,string &compilation, string &execution, map<string, string> &outputFiles, bool &executed, bool &interactive);
 	bool commandRunning(string adminticket);
 	void commandStop(string adminticket);
 	void commandMonitor(string userticket,Socket *s);

--- a/src/processMonitor.cpp
+++ b/src/processMonitor.cpp
@@ -11,6 +11,8 @@ using namespace std;
 #include <unistd.h>
 #include <signal.h>
 #include <wait.h>
+#include <iostream>
+#include <sstream>
 #include "lock.h"
 #include "processMonitor.h"
 #include "vpl-jail-server.h"
@@ -255,7 +257,7 @@ processMonitor::processMonitor(string ticket){
 }
 
 bool processMonitor::FileExists(string name){
-	return Util::fileExists(getHomePath()+"/"+name);
+	return Util::fileExists(getHomePath(name));
 }
 
 bool processMonitor::controlFileExists(string name){
@@ -263,7 +265,7 @@ bool processMonitor::controlFileExists(string name){
 }
 
 string processMonitor::readFile(string name){
-	return Util::readFile(getHomePath()+"/"+name);
+	return Util::readFile(getHomePath(name));
 }
 
 void processMonitor::writeFile(string name, const string &data){
@@ -295,7 +297,7 @@ void processMonitor::writeFile(string name, const string &data){
  * Delete a file from prisoner home directory
  */
 void processMonitor::deleteFile(string name){
-	Util::deleteFile(getHomePath()+"/"+name);
+	Util::deleteFile(getHomePath(name));
 }
 
 bool processMonitor::installScript(string to, string from){
@@ -379,7 +381,7 @@ void processMonitor::limitResultSize(string &r){
 		r = men+r.substr(0,JAIL_RESULT_MAX_SIZE/2)+men+r.substr(r.size()-JAIL_RESULT_MAX_SIZE/2);
 	}
 }
-void processMonitor::getResult(string &compilation, string &execution, bool &executed){
+void processMonitor::getResult(string &compilation, string &execution,  map<string, string> &outputfiles, bool &executed){
 	if(security != admin)
 		throw HttpException(internalServerErrorCode,"Security: requiere admin ticket for request");
 	processState state=getState(); //May be a problem with next acction
@@ -397,12 +399,25 @@ void processMonitor::getResult(string &compilation, string &execution, bool &exe
 			limitResultSize(compilation);
 			Util::deleteFile(fileName);
 		}
+
 		fileName=getControlPath("execution");
 		if((executed=Util::fileExists(fileName))){
 			execution=Util::readFile(fileName);
 			limitResultSize(execution);
 			Util::deleteFile(fileName);
 		}
+
+        fileName=getControlPath("outputfiles");
+        if (executed && Util::fileExists(fileName)) {
+            string outputFilenames = Util::readFile(fileName, false);
+            istringstream iss(outputFilenames);
+            string outputFilename;
+            while (getline(iss, outputFilename, '\n')) {
+                if ((outputFilename.size() > 0) && FileExists(outputFilename)) {
+                    outputfiles[outputFilename] = readFile(outputFilename);
+                }
+            }
+        }
 	}
 }
 
@@ -540,4 +555,15 @@ uint64_t processMonitor::getMemoryUsed(){
 void processMonitor::freeWatchDog(){
 	//TODO check process running based on /proc
 	//looking for inconsistences
+}
+
+void processMonitor::setOutputFilenames(vector<string> filenames) {
+    string output;
+    for(vector<string>::const_iterator it = filenames.begin(); it != filenames.end(); ++it){
+        output += *it;
+        output += "\n";
+    }
+
+    Lock lock(getControlPath());
+    Util::writeFile(getControlPath("outputfiles"), output);
 }

--- a/src/processMonitor.cpp
+++ b/src/processMonitor.cpp
@@ -13,6 +13,7 @@ using namespace std;
 #include <wait.h>
 #include <iostream>
 #include <sstream>
+#include <algorithm>
 #include "lock.h"
 #include "processMonitor.h"
 #include "vpl-jail-server.h"
@@ -560,7 +561,9 @@ void processMonitor::freeWatchDog(){
 void processMonitor::setOutputFilenames(vector<string> filenames) {
     string output;
     for(vector<string>::const_iterator it = filenames.begin(); it != filenames.end(); ++it){
-        output += *it;
+		string filename = *it;
+		replace(filename.begin(), filename.end(), '\n', ' ');
+		output += filename;
         output += "\n";
     }
 

--- a/src/processMonitor.h
+++ b/src/processMonitor.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include <string>
+#include <vector>
 using namespace std;
 #include "configurationFile.h"
 #include "configuration.h"
@@ -46,14 +47,21 @@ class processMonitor{
 	void removePrisonerHome();
 	static void catchSIGTERM(int n){}
 	void limitResultSize(string &);
+
 	void setControlPath(){
 		processControlPath=configuration->getControlPath()+"/p"+Util::itos(getPrisonerID());
 	}
+
 	string getControlPath(){
 		return processControlPath;
 	}
+
 	string getControlPath(string name){
 		return processControlPath+"/"+name;
+	}
+
+	string getHomePath(string name){
+		return getHomePath()+"/"+name;
 	}
 public:
 	processMonitor(string & adminticket, string & monitorticket, string & executionticket);
@@ -91,9 +99,10 @@ public:
 	uint64_t getMemoryUsed();
 	string getMemoryLimit();
 	string getCompilation();
-	void getResult(string &compilation, string &execution, bool &executed);
+	void getResult(string &compilation, string &execution, map<string, string> &outputfiles, bool &executed);
 	void setCompilationOutput(const string &compilation);
 	void setExecutionOutput(const string &execution, bool executed);
 	void freeWatchDog();
+	void setOutputFilenames(vector<string> filenames);
 };
 #endif

--- a/src/xml.h
+++ b/src/xml.h
@@ -74,6 +74,9 @@ public:
 		string getString() const {
 			if(tag=="string" || tag =="name")
 				return XML::decodeXML(getContent());
+			if(tag == "base64")
+				return Base64::decode(getContent());
+
 			throw HttpException(badRequestCode
 					,"RPC/XML parse type error",
 					"expected string or name  and found "+tag);


### PR DESCRIPTION
There are use-cases when text output of evaluation is not satisfactory - especially in case of programs/methods producing a visual output (e.g. a method using turtle graphics to draw a shape) or complex evaluation reports (including binary files). The proposed modification of jail allows for each submission to define a list of output files that are included in result of evaluation. 

Note that the modification fixes also the case when request consists of empty list of files to delete (filestodelete item).

Pull request for corresponding changes in moodle-mod_vpl will be initiated soon.